### PR TITLE
Refer to top button as "Buzz!" instead of "Red"

### DIFF
--- a/pybuzzers/pybuzzers.py
+++ b/pybuzzers/pybuzzers.py
@@ -7,7 +7,7 @@ BLUE = 1
 ORANGE = 2
 GREEN = 3
 YELLOW = 4
-COLOUR = {RED: "Red", BLUE: "Blue", ORANGE: "Orange", GREEN: "Green", YELLOW: "Yellow"}
+COLOUR = {RED: "Buzz!", BLUE: "Blue", ORANGE: "Orange", GREEN: "Green", YELLOW: "Yellow"}
 
 
 def list_connected_buzzers() -> list[dict]:


### PR DESCRIPTION
The top button is officially referred to as the Buzz! button, as on real buzzers, the logo is engraved/embossed/whatever into the button. (This is also how it's referred to in-game as well as manuals - I verified by checking my Mega Quiz manual and it calls this button the Buzz! button)
I've changed COLOUR to return "Buzz!" instead of "Red" to reflect this, so when it's shown to the user it'll have the proper name.